### PR TITLE
Add store-specific product management

### DIFF
--- a/controllers/handlerFactory.js
+++ b/controllers/handlerFactory.js
@@ -44,8 +44,9 @@ exports.getOne = (Model, popOptions) =>
 exports.getAll = (Model, popOptions) =>
   catchAsync(async (req, res, next) => {
     let filter = {};
-    // For nested routes (e.g., getting comments for a specific product)
+    // For nested routes like /products/:id/comments or /stores/:storeId/products
     if (req.params.id) filter = { product: req.params.id };
+    if (req.params.storeId) filter = { store: req.params.storeId };
     
     let query = Model.find(filter);
 

--- a/models/Product.js
+++ b/models/Product.js
@@ -30,6 +30,16 @@ const productSchema = new mongoose.Schema({
     default: 10
   },
   originalPrice: Number,
+  brand: String,
+  weight: Number,
+  dimensions: {
+    length: Number,
+    width: Number,
+    height: Number
+  },
+  sku: String,
+  returnPolicy: String,
+  warranty: String,
   views: {
     type: Number,
     default: 0
@@ -37,6 +47,10 @@ const productSchema = new mongoose.Schema({
   soldCount: {
     type: Number,
     default: 0
+  },
+  isActive: {
+    type: Boolean,
+    default: true
   },
   images: [String],
   specifications: Object,
@@ -83,6 +97,15 @@ const productSchema = new mongoose.Schema({
 productSchema.pre('save', function(next) {
   this.slug = slugify(this.name, { lower: true });
   next();
+});
+
+// Calculate discount percentage virtual
+productSchema.virtual('discount').get(function () {
+  if (this.originalPrice && this.price) {
+    const discount = ((this.originalPrice - this.price) / this.originalPrice) * 100;
+    return Math.round(discount * 10) / 10;
+  }
+  return 0;
 });
 
 // Virtual 'reviews' field that populates from the Rating model

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -49,7 +49,7 @@ router.get('/my-products', restrictTo('store_owner', 'admin'), productController
 
 // Using /:id for consistency
 router.route('/:id')
-    .put(restrictTo('store_owner', 'admin'), productController.updateProduct)
-    .delete(restrictTo('store_owner', 'admin'), productController.deleteProduct);
+    .put(restrictTo('store_owner', 'admin'), isStoreOwnerForProduct, productController.updateProduct)
+    .delete(restrictTo('store_owner', 'admin'), isStoreOwnerForProduct, productController.deleteProduct);
 
 module.exports = router;

--- a/routes/storeRoutes.js
+++ b/routes/storeRoutes.js
@@ -6,10 +6,16 @@ const { protect, restrictTo } = require('../middleware/auth');
 
 const router = express.Router();
 
-// Nested route: Redirect requests for products within a store to the product controller
-// This handles GET /api/stores/:storeId/products
-// This approach avoids circular dependencies between routers.
-router.get('/:storeId/products', productController.getAllProducts);
+// Nested route for products within a store
+router
+  .route('/:storeId/products')
+  .get(productController.getAllProducts)
+  .post(
+    protect,
+    restrictTo('store_owner', 'admin'),
+    productController.setStoreIdFromParam,
+    productController.createProduct
+  );
 
 // --- Public Routes ---
 router.get('/', storeController.getAllStores);


### PR DESCRIPTION
## Summary
- expand `Product` model with brand details, dimensions, SKU and activation flag
- add discount virtual field
- support `/stores/:storeId/products` route with POST and GET
- restrict product update/delete to store owners
- enhance product retrieval with pagination and store filtering

## Testing
- `npm install`
- `npm start` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68453ef5c4b4832eb18d5e574edd7334