### PR TITLE
Add notification API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,36 @@ Authorization: Bearer <access_token>
 
 The user must be logged in to access this endpoint. If the token is missing or invalid, the server returns a `401 Unauthorized` error.
 
+
+## Notification Endpoints
+
+### GET `/notifications`
+Retrieve notifications for the authenticated user. Supports optional query parameters:
+- `type`: `all`, `order_status_update`, `new_order`, `payment_received`, `delivery_update`
+- `isRead`: `true` or `false`
+- `page`: page number (default `1`)
+- `limit`: items per page (default `20`)
+
+Example success response:
+```json
+{
+  "success": true,
+  "data": [/* array of notifications */],
+  "unreadCount": 5,
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 45,
+    "pages": 3
+  }
+}
+```
+
+### PATCH `/notifications/:id/read`
+Mark a specific notification as read.
+
+### PATCH `/notifications/mark-all-read`
+Mark all of the user's notifications as read. Returns the number of marked documents.
+
+### DELETE `/notifications/:id`
+Delete a notification belonging to the authenticated user.

--- a/controllers/notificationController.js
+++ b/controllers/notificationController.js
@@ -1,18 +1,84 @@
 const Notification = require('../models/Notification');
-const factory = require('./handlerFactory');
-const catchAsync =require('../utils/catchAsync');
+const catchAsync = require('../utils/catchAsync');
+const AppError = require('../utils/appError');
 
-exports.getNotifications = factory.getAll(Notification, { user: (req) => req.user.id });
+exports.getNotifications = catchAsync(async (req, res, next) => {
+  const page = parseInt(req.query.page, 10) || 1;
+  const limit = parseInt(req.query.limit, 10) || 20;
+  const skip = (page - 1) * limit;
 
-exports.markAsRead = factory.updateOne(Notification);
+  const baseFilter = { $or: [{ recipient: req.user.id }, { user: req.user.id }] };
+  const filter = { ...baseFilter };
 
-exports.deleteNotification = factory.deleteOne(Notification);
+  if (req.query.type && req.query.type !== 'all') {
+    filter.type = req.query.type;
+  }
+  if (typeof req.query.isRead !== 'undefined') {
+    filter.isRead = req.query.isRead === 'true';
+  }
+
+  const [notifications, total, unreadCount] = await Promise.all([
+    Notification.find(filter).sort('-createdAt').skip(skip).limit(limit),
+    Notification.countDocuments(filter),
+    Notification.countDocuments({ ...baseFilter, isRead: false })
+  ]);
+
+  res.status(200).json({
+    success: true,
+    data: notifications,
+    unreadCount,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit)
+    }
+  });
+});
+
+exports.markAsRead = catchAsync(async (req, res, next) => {
+  const notif = await Notification.findOneAndUpdate(
+    { _id: req.params.notificationId, $or: [{ recipient: req.user.id }, { user: req.user.id }] },
+    { isRead: true, readAt: new Date() },
+    { new: true }
+  );
+
+  if (!notif) {
+    return next(new AppError('No notification found with that ID', 404));
+  }
+
+  res.status(200).json({
+    success: true,
+    data: {
+      _id: notif._id,
+      isRead: notif.isRead,
+      readAt: notif.readAt
+    }
+  });
+});
 
 exports.markAllAsRead = catchAsync(async (req, res, next) => {
-    await Notification.updateMany({ user: req.user.id, isRead: false }, { isRead: true });
-    
-    res.status(200).json({
-        success: true,
-        message: 'All notifications marked as read.'
-    });
+  const result = await Notification.updateMany(
+    { $or: [{ recipient: req.user.id }, { user: req.user.id }], isRead: false },
+    { isRead: true, readAt: new Date() }
+  );
+
+  res.status(200).json({
+    success: true,
+    data: { markedCount: result.modifiedCount },
+    message: 'All notifications marked as read'
+  });
+});
+
+exports.deleteNotification = catchAsync(async (req, res, next) => {
+  const notif = await Notification.findOneAndDelete({
+    _id: req.params.notificationId,
+    $or: [{ recipient: req.user.id }, { user: req.user.id }]
+  });
+
+  if (!notif) {
+    return next(new AppError('No notification found with that ID', 404));
+  }
+
+  res.status(200).json({ success: true, message: 'Notification deleted successfully' });
 });

--- a/routes/notificationRoutes.js
+++ b/routes/notificationRoutes.js
@@ -8,8 +8,7 @@ router.use(protect);
 
 router.get('/', notificationController.getNotifications);
 router.patch('/mark-all-read', notificationController.markAllAsRead);
-router.route('/:id')
-  .patch(notificationController.markAsRead)
-  .delete(notificationController.deleteNotification);
+router.patch('/:notificationId/read', notificationController.markAsRead);
+router.delete('/:notificationId', notificationController.deleteNotification);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- implement full notification controller logic
- add dedicated routes for marking notifications read and deletion
- document notification endpoints in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails to connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6845453b9f88832e89824db6d68267df